### PR TITLE
Bump jspdf to v4.0.0 to resolve critical issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "html2canvas": "^1.4.1",
-        "jspdf": "^3.0.2",
+        "jspdf": "^4.0.0",
         "lucide-react": "^0.536.0",
         "openai": "^5.11.0",
         "react": "^19.1.1",
@@ -2779,9 +2779,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
-      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -12966,12 +12966,12 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.2.tgz",
-      "integrity": "sha512-G0fQDJ5fAm6UW78HG6lNXyq09l0PrA1rpNY5i+ly17Zb1fMMFSmS+3lw4cnrAPGyouv2Y0ylujbY2Ieq3DSlKA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
+      "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.9",
+        "@babel/runtime": "^7.28.4",
         "fast-png": "^6.2.0",
         "fflate": "^0.8.1"
       },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "html2canvas": "^1.4.1",
-    "jspdf": "^3.0.2",
+    "jspdf": "^4.0.0",
     "lucide-react": "^0.536.0",
     "openai": "^5.11.0",
     "react": "^19.1.1",


### PR DESCRIPTION
jsPDF prior to v4 has a critical local file inclusion vulnerability which could be leveraged to expose data/secrets from applications.

Resolves:
- https://github.com/SMARTeacher/add-students-flow-poc/security/dependabot/15